### PR TITLE
fix: Add configurable commit message

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   conventional-commits-pr:
-#    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     name: Validate Conventional Commits PR
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   conventional-commits-pr:
-    if: github.event.pull_request.draft == false
+#    if: github.event.pull_request.draft == false
     name: Validate Conventional Commits PR
     runs-on: ubuntu-latest
     steps:

--- a/action.yaml
+++ b/action.yaml
@@ -15,10 +15,6 @@ inputs:
     description: 'Subdirectory to use with buf push'
     required: false
     default: '.'
-  ref:
-    description: 'Ref to checkout'
-    required: false
-    default: ${{ github.head_ref }}
   lint:
     description: 'Run `buf lint`'
     required: false
@@ -50,11 +46,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        token: ${{ inputs.token }}
-        ref: ${{ inputs.ref }}
     - name: Configure git
       uses: fregante/setup-git-user@v1
     - name: Setup Cache

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: 'Action Buf'
+name: 'Action Buf' #
 description: 'Runs buf commmands to lint and generate protos'
 inputs:
   buf-user:

--- a/action.yaml
+++ b/action.yaml
@@ -42,7 +42,7 @@ inputs:
   commit-message:
     description: 'commit message to use when pushing generated code'
     required: false
-    default: '[skip ci]'
+    default: '[skip ci] buf generated code from protos'
 runs:
   using: "composite"
   steps:

--- a/action.yaml
+++ b/action.yaml
@@ -42,7 +42,7 @@ inputs:
   commit-message:
     description: 'commit message to use when pushing generated code'
     required: false
-    default: '[skip ci] buf generated code from protos'
+    default: 'chore: buf generated code from protos [skip ci] '
 runs:
   using: "composite"
   steps:

--- a/action.yaml
+++ b/action.yaml
@@ -15,6 +15,14 @@ inputs:
     description: 'Subdirectory to use with buf push'
     required: false
     default: '.'
+  checkout:
+    description: 'set to true to checkout the repository, set to false if you are checking out the repository before using this action'
+    required: false
+    default: true
+  ref:
+    description: 'Ref to checkout'
+    required: false
+    default: ${{ github.head_ref }}
   lint:
     description: 'Run `buf lint`'
     required: false
@@ -46,6 +54,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout
+      if: inputs.checkout == 'true'
+      uses: actions/checkout@v2
+      with:
+        token: ${{ inputs.token }}
+        ref: ${{ inputs.ref }}
     - name: Configure git
       uses: fregante/setup-git-user@v1
     - name: Setup Cache

--- a/action.yaml
+++ b/action.yaml
@@ -103,8 +103,6 @@ runs:
       if: inputs.generate == 'true'
       shell: bash
       run: |
-        pwd
-        ls -al
         buf generate
     - name: Commit generated protos
       if: inputs.generate == 'true'

--- a/action.yaml
+++ b/action.yaml
@@ -112,6 +112,8 @@ runs:
       if: inputs.generate == 'true'
       shell: bash
       run: |
+        pwd
+        ls -al
         buf generate
     - name: Commit generated protos
       if: inputs.generate == 'true'

--- a/action.yaml
+++ b/action.yaml
@@ -43,6 +43,10 @@ inputs:
     description: 'Run `buf push`'
     required: false
     default: 'false'
+  commit-message:
+    description: 'commit message to use when pushing generated code'
+    required: false
+    default: '[skip ci]'
 runs:
   using: "composite"
   steps:
@@ -112,6 +116,8 @@ runs:
     - name: Commit generated protos
       if: inputs.generate == 'true'
       uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: ${{ inputs.commit-message }}
     - name: Create BSR repo
       if: inputs.push == 'true'
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: 'Action Buf' #
+name: 'Action Buf'
 description: 'Runs buf commmands to lint and generate protos'
 inputs:
   buf-user:


### PR DESCRIPTION
- Made checkout optional
- Default commit message to include `[skip ci] ` so that pushing the generated code doesn't re-trigger workflows