### PR TITLE
fix: Make default commit message ci friendly. If it includes language…

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -50,7 +50,7 @@ inputs:
   commit-message:
     description: 'commit message to use when pushing generated code'
     required: false
-    default: 'chore: buf generated code from protos [skip ci] '
+    default: 'chore: buf generated code from protos'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
… that causes ci to not run then it doesn't run even when things are squash merged, so it won't work at all.