### PR TITLE
fix: remove skip-ci from default commit message

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -50,7 +50,7 @@ inputs:
   commit-message:
     description: 'commit message to use when pushing generated code'
     required: false
-    default: 'chore: buf generated code from protos [skip ci]'
+    default: 'chore: buf generated code from protos'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
as long as the default github token is being used for this action, ci doesn't get reran. the existence of the skip-ci text consequently causes releases to not run the ci release workflows, so remove it by default.