### PR TITLE
fix: update buf version to 1.48.0

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -79,7 +79,7 @@ runs:
     - name: Configure git
       uses: fregante/setup-git-user@v2
     - name: Setup buf
-      uses: bufbuild/buf-setup-action@v1.9.0
+      uses: bufbuild/buf-setup-action@v1.48.0
       with:
         github_token: ${{ github.token }}
     - name: Sign into BSR


### PR DESCRIPTION
This PR was made because in a different project I switched a `lint use` category in the `buf.yaml` from `DEFAULT` to `STANDARD`, which the current `buf` version of this action does not support.
https://buf.build/docs/configuration/v2/buf-yaml/#lint

Edit: While there is a `version:` input, the upgraded _action_ version also updates the default _buf_ version: https://github.com/bufbuild/buf-setup-action

Here is the warning that prompted the change, which I got from `buf lint` when I was using `1.48.0` while continuing to use `DEFAULT`:
```
WARN    Category DEFAULT referenced in your buf.yaml is deprecated. It has been replaced by category STANDARD.

        The concept of a default rule has been introduced. A default rule is a rule that will be run
        if no rules are explicitly configured in your buf.yaml. Run buf config ls-lint-rules or
        buf config ls-breaking-rules to see which rules are defaults. With this introduction, having a category
        also named DEFAULT is confusing, as while it happpens that all the rules in the DEFAULT category
        are also default rules, the name has become overloaded.

        As with all buf changes, this change is backwards-compatible: DEFAULT will continue to work.
        We recommend replacing DEFAULT in your buf.yaml, but no action is immediately necessary.
```