### PR TITLE
fix: Revert "fix: test triggering release"

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: 'Action Buf' #
+name: 'Action Buf'
 description: 'Runs buf commmands to lint and generate protos'
 inputs:
   working-directory:


### PR DESCRIPTION
Reverts catalystcommunity/action-buf#28

Removes a test comment and also re-triggers a release, now that the issue with closed pull_request workflows seems to be resolved.
https://github.com/orgs/community/discussions/148367