### PR TITLE
fix: revert to catalystsquad package name until a catalystcommunity one is released

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -100,7 +100,7 @@ runs:
       # using our own fork of protobuf-ts to support `?` syntax until our PR is merged to their repo
       shell: bash
       run: |
-        npm install -g @catalystcommunity/protobuf-ts
+        npm install -g @catalystsquad/protobuf-ts
         go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
         go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
         go install github.com/catalystcommunity/go-proto-gql/protoc-gen-gql@566f192ea0729aa0daddcacf0b3ec2f15f468bdc


### PR DESCRIPTION
The lack of a `@catalystcommunity/protobuf-ts` package is breaking this action, so I'm reverting to the existing `@catalystsquad/protobuf-ts` package.

The package in question is here: https://www.npmjs.com/package/@catalystsquad/protobuf-ts
It has a github repo, which does redirect to the community repo here: https://github.com/catalystcommunity/protobuf-ts

The repo hasn't been updated in three years, and I don't want to go figure out how to release the package under a new name manually. I think we'll be fine staying on the existing npm name until we need to release a new version under a new name.