### PR TITLE
fix: update hash for catalystcommunity/go-proto-gql to fix package name in go.mod

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -103,7 +103,7 @@ runs:
         npm install -g @catalystsquad/protobuf-ts
         go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
         go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-        go install github.com/catalystcommunity/go-proto-gql/protoc-gen-gql@566f192ea0729aa0daddcacf0b3ec2f15f468bdc
+        go install github.com/catalystcommunity/go-proto-gql/protoc-gen-gql@785724eb5d0c71d034c68a2f4bc1037b27156c85
     - name: Run buf lint
       if: inputs.lint == 'true'
       uses: bufbuild/buf-lint-action@v1


### PR DESCRIPTION
This updates to the hash where we moved the repo to catalystcommunity. Fixes the package name error when installing at the last hash:

```
go: github.com/catalystcommunity/go-proto-gql/protoc-gen-gql@566f192ea0729aa0daddcacf0b3ec2f15f468bdc: version constraints conflict:
	github.com/catalystcommunity/go-proto-gql@v0.8.4-0.20221005195438-566f192ea072: parsing go.mod:
	module declares its path as: github.com/catalystsquad/go-proto-gql
	        but was required as: github.com/catalystcommunity/go-proto-gql
```

Previous hash go.mod blob:https://github.com/catalystcommunity/go-proto-gql/blob/566f192ea0729aa0daddcacf0b3ec2f15f468bdc/go.mod

New hash go.mod blob: https://github.com/catalystcommunity/go-proto-gql/blob/785724eb5d0c71d034c68a2f4bc1037b27156c85/go.mod